### PR TITLE
feat(backend): add embedding service for multilingual encoding

### DIFF
--- a/neev-backend/embeddings/service.py
+++ b/neev-backend/embeddings/service.py
@@ -1,0 +1,42 @@
+"""
+NEEV - Embedding Service
+This service:
+- Loads a multilingual sentence-transformer
+- Encodes NCO entries into vectors
+- Prepares vectors for FAISS index
+"""
+
+from typing import List, Dict, Tuple
+import numpy as np
+
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception as e:
+    # Friendly message if sentence-transformers is not installed
+    raise RuntimeError("Please install dependencies: pip install -r requirements.txt") from e
+
+class EmbeddingService:
+    def __init__(self, model_name: str = "paraphrase-multilingual-MiniLM-L12-v2"):
+        self.model = SentenceTransformer(model_name)
+        self.nco_entries: List[Dict] = []
+        self.embeddings: np.ndarray = None
+
+    def load_nco(self, data: List[Dict]) -> None:
+        """Store entries; later we’ll add validation/hierarchy checks."""
+        self.nco_entries = data
+
+    def _compose_text(self, item: Dict]) -> str:
+        """
+        What we encode: title + description.
+        We can tweak fields later for better performance.
+        """
+        title = item.get("title_norm") or item.get("title") or ""
+        desc = item.get("desc_norm") or item.get("description") or ""
+        return f"{title} [SEP] {desc}"
+
+    def encode(self) -> np.ndarray:
+        if not self.nco_entries:
+            raise ValueError("No NCO entries loaded")
+        corpus = [self._compose_text(x) for x in self.nco_entries]
+        self.embeddings = self.model.encode(corpus, convert_to_numpy=True, normalize_embeddings=True)
+        return self.embeddings


### PR DESCRIPTION
This pull request introduces a new `EmbeddingService` class to the `neev-backend/embeddings/service.py` file, providing a structured way to load NCO entries and encode them into vector embeddings using a multilingual sentence-transformer. The main changes are focused on establishing a reusable and extensible embedding service for downstream tasks such as FAISS indexing.

Embedding service implementation:

* Added new `EmbeddingService` class that loads a multilingual sentence-transformer model (`paraphrase-multilingual-MiniLM-L12-v2` by default) and manages NCO entries and their embeddings.
* Implemented `load_nco` method to store NCO entries for later encoding.
* Added `_compose_text` method to concatenate normalized or raw title and description fields for each entry, preparing text for embedding.
* Provided `encode` method that encodes all loaded NCO entries into normalized numpy embeddings using the sentence-transformer model.
* Included a friendly error message if the `sentence-transformers` dependency is missing, guiding the user to install requirements.