### PR TITLE
feat(search): add FAISS flat indexer with IP for normalized vectors

### DIFF
--- a/neev-backend/search/indexer.py
+++ b/neev-backend/search/indexer.py
@@ -1,0 +1,40 @@
+"""
+NEEV - FAISS Indexer
+- Builds a Flat (exact) FAISS index for ~3,600 vectors (fast enough on CPU)
+- Provides top-k search
+"""
+
+from typing import List, Dict, Tuple
+import numpy as np
+import faiss
+
+class FaissIndexer:
+    def __init__(self):
+        self.index = None
+        self.id_to_meta: List[Dict] = []
+
+    def build(self, embeddings: np.ndarray, metadata: List[Dict]) -> None:
+        """
+        Build a cosine-similarity-like index by using normalized vectors and inner product.
+        """
+        if embeddings.ndim != 2:
+            raise ValueError("Embeddings must be 2D array of shape (N, D)")
+        dim = embeddings.shape[1]
+        self.index = faiss.IndexFlatIP(dim)  # Inner Product on normalized vectors ~= cosine
+        self.index.add(embeddings)
+        self.id_to_meta = metadata
+
+    def search(self, query_vec: np.ndarray, k: int = 5) -> List[Tuple[Dict, float]]:
+        """
+        query_vec: shape (D,) or (1, D) normalized
+        Returns: list of (metadata, score)
+        """
+        if query_vec.ndim == 1:
+            query_vec = query_vec.reshape(1, -1)
+        scores, ids = self.index.search(query_vec, k)
+        results = []
+        for i, sc in zip(ids, scores):
+            if i == -1:
+                continue
+            results.append((self.id_to_meta[i], float(sc)))
+        return results


### PR DESCRIPTION
This pull request introduces a new FAISS-based indexer to the `neev-backend/search/indexer.py` file, providing efficient top-k vector search functionality using cosine similarity (via normalized inner product). The main addition is the `FaissIndexer` class, which supports index building and search.

New FAISS indexer implementation:

* Added the `FaissIndexer` class with methods to build a FAISS index from embeddings and associated metadata, and to perform top-k similarity searches.
* The indexer uses normalized vectors and inner product to approximate cosine similarity, suitable for ~3,600 vectors on CPU.
* Search results return metadata and similarity scores for the top matches.